### PR TITLE
Adding view to see boxes owned by a specific group

### DIFF
--- a/manager-gui/src/app/containers/group/group.tsx
+++ b/manager-gui/src/app/containers/group/group.tsx
@@ -2,19 +2,25 @@ import * as React from 'react';
 import { Component, ReactNode, SFC } from 'react';
 import { connect } from 'react-redux';
 import { Redirect } from 'react-router';
-import { Dimmer, Loader } from 'semantic-ui-react';
+import { Dimmer, Loader, Table } from 'semantic-ui-react';
 
-import { GroupState, RootState } from '../../models';
+import { Box, BoxState, RootState } from '../../models';
+import { findBoxes } from '../../state/actions';
 import { MainHeader } from '../../components';
 
+interface RouteProps {
+    match: any;
+}
+
 interface ComponentStateProps {
-    groupState: GroupState;
+    boxState: BoxState;
 }
 
 interface ComponentDispatchProps {
+    findBoxes: (groupId: number) => Promise<any>;
 }
 
-type ComponentProps = ComponentDispatchProps & ComponentStateProps;
+type ComponentProps = ComponentDispatchProps & ComponentStateProps & RouteProps;
 
 interface ComponentState {
     boxId?: number;
@@ -29,25 +35,68 @@ class GroupContainer extends Component<ComponentProps, ComponentState> {
         this.state = initialState;
     }
 
+    componentDidMount(){
+        this.props.findBoxes(Number(this.props.match.params.groupId));
+    }
+
+
     public render(): ReactNode {
         const { boxId } = this.state;
-        const { groupState } = this.props;
-        const { loading } = groupState;
+        const { boxState } = this.props;
+//        const loading = groupState.loading;
+        const { boxes, loading } = boxState; 
 
         if (boxId) {
             return <Redirect to={`/box/${boxId}`} />;
         } else if (loading) {
             return <Loading />;
         } else {
+            console.log(boxes)
             return (
                 <div>
                     <MainHeader title='Vagrant Repository Manager' />
-                    <h3>Group</h3>
+                    <Boxes boxes={boxes} onClick={this.onListItemClick} />
                 </div>
             );
         }
     }
+    private onListItemClick = (boxId: number) => {
+        this.setState({ boxId: boxId });
+    };
 }
+
+interface BoxesProps {
+    boxes: Box[];
+    onClick: (groupId: number) => void;
+}
+
+const Boxes: SFC<BoxesProps> = (props) => {
+    const { boxes, onClick } = props;
+    return (
+        <div>
+        {boxes[0] ? <h3>Group: {boxes[0].group.name}</h3> : null}
+            <Table celled selectable>
+                <Table.Header>
+                    <Table.Row>
+                        <Table.HeaderCell>Box name</Table.HeaderCell>
+                        <Table.HeaderCell>Description</Table.HeaderCell>
+                    </Table.Row>
+                </Table.Header>
+                <Table.Body>
+                    {boxes.map((box, index) => {
+                        const { id, name, description } = box;
+                        return (
+                            <Table.Row key={index} className='clickable-table-row' onClick={() => onClick(id)}>
+                                <Table.Cell>{name}</Table.Cell>
+                                <Table.Cell>{description}</Table.Cell>
+                            </Table.Row>
+                        );
+                    })}
+                </Table.Body>
+            </Table>
+        </div>
+    );
+};
 
 const Loading: SFC<{}> = () => {
     return (
@@ -61,10 +110,13 @@ const Loading: SFC<{}> = () => {
 };
 
 const mapStateToProps = (state: RootState): ComponentStateProps => ({
-    groupState: state.groupState
+    boxState: state.boxState
 });
 
-const mapDispatchToProps = (dispatch): ComponentDispatchProps => ({});
+const mapDispatchToProps = (dispatch): ComponentDispatchProps => ({
+        findBoxes:(groupId: number) => dispatch(findBoxes(groupId))
+
+});
 
 const ConnectedGroupContainer = connect(mapStateToProps, mapDispatchToProps)(GroupContainer);
 

--- a/manager-gui/src/app/models/constants/action-types.ts
+++ b/manager-gui/src/app/models/constants/action-types.ts
@@ -9,3 +9,9 @@ export enum FindGroupsActionType {
     SUCCESS = '[groups] FIND SUCCESS',
     ERROR = '[groups] FIND ERROR'
 }
+
+export enum FindBoxesActionType {
+    LOADING = '[boxes] FIND LOADING',
+    SUCCESS = '[boxes] FIND SUCCESS',
+    ERROR = '[boxes] FIND ERROR'
+}

--- a/manager-gui/src/app/models/types/boxes.tsx
+++ b/manager-gui/src/app/models/types/boxes.tsx
@@ -1,0 +1,40 @@
+import { FindBoxesActionType } from '../constants';
+import { Error } from './globals';
+import { Group } from '../';
+
+export interface Box {
+    id: number;
+    name: string;
+    description: string;
+    group: Group;
+}
+
+export interface BoxState {
+    loading: boolean;
+    boxes: Box[];
+    error?: any;
+}
+
+export const initialBoxState: BoxState = {
+    loading: false,
+    boxes: []
+};
+
+export interface FindBoxesLoadingAction {
+    type: FindBoxesActionType.LOADING,
+    loading: boolean
+}
+
+export interface FindBoxesSuccessAction {
+    type: FindBoxesActionType.SUCCESS,
+    payload: Box[]
+}
+
+export interface FindBoxesErrorAction {
+    type: FindBoxesActionType.ERROR,
+    error: Error
+}
+
+export type FindBoxesAction = FindBoxesLoadingAction | FindBoxesSuccessAction | FindBoxesErrorAction;
+
+export type BoxAction =  FindBoxesAction;

--- a/manager-gui/src/app/models/types/globals.ts
+++ b/manager-gui/src/app/models/types/globals.ts
@@ -1,11 +1,14 @@
 import { GroupState, initialGroupState } from './groups';
+import { BoxState, initialBoxState } from './boxes';
 
 export interface RootState {
     groupState: GroupState;
+    boxState: BoxState;
 }
 
 export const initialRootState: RootState = {
-    groupState: initialGroupState
+    groupState: initialGroupState,
+    boxState: initialBoxState
 };
 
 export interface Error {

--- a/manager-gui/src/app/models/types/index.ts
+++ b/manager-gui/src/app/models/types/index.ts
@@ -1,2 +1,3 @@
 export * from './globals';
 export * from './groups';
+export * from './boxes';

--- a/manager-gui/src/app/state/actions/boxes.ts
+++ b/manager-gui/src/app/state/actions/boxes.ts
@@ -1,0 +1,29 @@
+import axios from 'axios';
+
+import {
+    Box,
+    FindBoxesActionType,
+    FindBoxesErrorAction,
+    FindBoxesLoadingAction,
+    FindBoxesSuccessAction,
+} from '../../models';
+
+const findBoxesLoading = (loading: boolean): FindBoxesLoadingAction => ({type: FindBoxesActionType.LOADING, loading});
+const findBoxesSuccess = (payload: Box[]): FindBoxesSuccessAction => ({type: FindBoxesActionType.SUCCESS, payload});
+const findBoxesError = (error: any): FindBoxesErrorAction => ({type: FindBoxesActionType.ERROR, error});
+
+const rootPath = '/api/groups';
+
+export function findBoxes(id: number) {
+    return (dispatch) => {
+        dispatch(findBoxesLoading(true));
+        const url = id ? `${rootPath}/${id}/boxes` : rootPath;
+        return axios.get(url)
+            .then((response) => {
+                return dispatch(findBoxesSuccess(response.data));
+            })
+            .catch((error) => {
+                return dispatch(findBoxesError(error));
+            });
+    };
+}

--- a/manager-gui/src/app/state/actions/index.ts
+++ b/manager-gui/src/app/state/actions/index.ts
@@ -1,1 +1,2 @@
 export * from './groups';
+export * from './boxes';

--- a/manager-gui/src/app/state/reducers/boxes.ts
+++ b/manager-gui/src/app/state/reducers/boxes.ts
@@ -1,0 +1,52 @@
+import {
+    BoxState,
+    BoxAction,
+    FindBoxesAction,
+    FindBoxesActionType,
+    initialBoxState
+} from '../../models';
+
+export function reducer(state: BoxState = initialBoxState, action: BoxAction): BoxState {
+    switch (action.type) {
+        case FindBoxesActionType.LOADING:
+        case FindBoxesActionType.SUCCESS:
+        case FindBoxesActionType.ERROR:
+            return find(state, action);
+        default:
+            return state;
+    }
+}
+
+export function find(state: BoxState = initialBoxState, action: FindBoxesAction): BoxState {
+    switch (action.type) {
+        case FindBoxesActionType.LOADING: {
+            const {loading} = action;
+            return {...state, loading: loading};
+        }
+
+        case FindBoxesActionType.SUCCESS: {
+            const {payload} = action;
+            let {boxes} = state;
+            if (payload) {
+                payload.forEach(box => {
+                    let index = boxes.indexOf(box);
+                    if (~index) {
+                        boxes[index] = box;
+                    } else {
+                        boxes = boxes.concat(payload);
+                    }
+                });
+            }
+            return {...initialBoxState, boxes: payload};
+        }
+
+        case FindBoxesActionType.ERROR: {
+            const {error} = action;
+            return {...initialBoxState, error: error};
+        }
+
+        default: {
+            return state;
+        }
+    }
+}

--- a/manager-gui/src/app/state/reducers/index.ts
+++ b/manager-gui/src/app/state/reducers/index.ts
@@ -2,9 +2,12 @@ import { combineReducers } from 'redux';
 
 import { RootState } from '../../models';
 import * as groups from './groups';
+import * as boxes from './boxes';
 
 const {reducer: groupsReducer} = groups;
+const {reducer: boxesReducer} = boxes;
 
 export const rootReducer = combineReducers<RootState>({
-    groupState: groupsReducer
+    groupState: groupsReducer,
+    boxState: boxesReducer
 });


### PR DESCRIPTION
Each box for the group is now listed in a new view with the group name listed above the list itself.